### PR TITLE
ARREGLA REEMPLAZO PARA XML AL CONSTRUIR DTE DESDE XML

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "sasco/libredte",
+    "name": "leonardobarrientosc/libredte",
     "description": "Biblioteca para trabajo con DTE del SII de Chile",
     "type": "library",
     "keywords": ["dte", "sii", "facturación electrónica"],

--- a/lib/Sii/EnvioDte.php
+++ b/lib/Sii/EnvioDte.php
@@ -166,7 +166,7 @@ class EnvioDte extends \sasco\LibreDTE\Sii\Base\Envio
         // generar XML de los DTE que se deberán incorporar
         $DTEs = [];
         foreach ($this->dtes as &$DTE)
-            $DTEs[] = trim(str_replace('<?xml version="1.0" encoding="ISO-8859-1"?>', '', $DTE->saveXML()));
+            $DTEs[] = trim(str_replace(array('<?xml version="1.0" encoding="ISO-8859-1"?>','<?xml version="1.0"?>'), array('',''), $DTE->saveXML()));
         // firmar XML del envío y entregar
         $xml = str_replace('<DTE/>', implode("\n", $DTEs), $xmlEnvio);
         $this->xml_data = $this->Firma ? $this->Firma->signXML($xml, '#SetDoc', 'SetDTE', true) : $xml;


### PR DESCRIPTION
En EnvioDTE Linea 169:
$DTEs[] = trim(str_replace(array('<?xml version="1.0" encoding="ISO-8859-1"?>','<?xml version="1.0"?>'), array('',''), $DTE->saveXML()));