### PR TITLE
Lo que se indica

### DIFF
--- a/lib/Sii/EnvioDte.php
+++ b/lib/Sii/EnvioDte.php
@@ -10,7 +10,7 @@
  * 3 de la Licencia, o (a su elección) cualquier versión posterior de la
  * misma.
  *
- * Este programa se distribuye con la esperanza de que sea útil, perosetCaratula
+ * Este programa se distribuye con la esperanza de que sea útil, pero
  * SIN GARANTÍA ALGUNA; ni siquiera la garantía implícita
  * MERCANTIL o de APTITUD PARA UN PROPÓSITO DETERMINADO.
  * Consulte los detalles de la Licencia Pública General Affero de GNU para


### PR DESCRIPTION
Setea arreglo para tener disponible desde el método getCaratula() los datos de la carátula que fueron utilizados en el envío. Ej: para generar el nombre del xml a guardar en disco.

...
$Caratula = $this->EnvioDTE->getCaratula();

$fileNameEnvioDTE = 'dte_'.$this->Dte->getTipo().'_'.$this->Dte->getFolio().'_'.$this->Dte->getEmisor().'_'.$Caratula['RutReceptor'] .'_'.str_replace(['-', ':', 'T'], '', $Caratula['TmstFirmaEnv']).'.xml';
...
