### PR TITLE
Se modifica el metodo loadXML

### DIFF
--- a/lib/XML.php
+++ b/lib/XML.php
@@ -132,10 +132,20 @@ class XML extends \DomDocument
      * @author Esteban De La Fuente Rubio, DeLaF (esteban[at]sasco.cl)
      * @version 2016-11-21
      */
-    public function loadXML($source, $options = null)
-    {
-        return $source ? parent::loadXML($this->iso2utf($source), $options) : false;
-    }
+     public function loadXML($source, $options = null)
+     {
+         $tRetorno = $source ? parent::load($this->iso2utf($source), $options) : false;
+
+         if (!$tRetorno){
+           $tRetorno = parent::loadXML($this->iso2utf($source), $options);
+         }
+         if(!$tRetorno){
+           foreach (libxml_get_errors() as $error) {
+               echo "Error: " . $error->message;
+           }
+         }
+         return $tRetorno;
+     }
 
     /**
      * Método para realizar consultas XPATH al documento XML


### PR DESCRIPTION
Modifiqué el método loadXML, puesto que intenté cargar los XML de firma directo desde un fichero y no funcionó. Luego, revisé que estos se cargaban desde una variable, la cual debía contener el contenido del fichero entregado por el SII, tanto los folios o la firma. 
El método loadXML ahora recibe, indistintamente, una ruta o el contenido de un XML. 