### PR TITLE
Removido correción automática de NumItem

### DIFF
--- a/lib/Sii/Certificacion/SetPruebas.php
+++ b/lib/Sii/Certificacion/SetPruebas.php
@@ -385,10 +385,6 @@ class SetPruebas
                     'CodRef' => $referencia['codigo'],
                     'RazonRef' => $caso['referencia']['razon'],
                 ];
-                // si la referencia es corrige giro se asigna automáticamente la corrección
-                if (isset($documento['Referencia'][1]['RazonRef']) and strpos($documento['Referencia'][1]['RazonRef'], 'CORRIGE GIRO')===0) {
-                    $documento['Detalle'][0]['NmbItem'] = 'DONDE DICE Servicios integrales de informática DEBE DECIR Informática';
-                }
                 // agregar totales
                 $documento['Encabezado']['Totales'] = $referencia['Totales'];
                 // agregar tasa de IVA si corresponde


### PR DESCRIPTION
En el set de prueba se elimina el código que forza la sobreescritura
de NmbItem en la referencia, que crea errores en el archivo de set de
prueba.