### PR TITLE
Se agrega al header Content-Type al request

### DIFF
--- a/lib/Sii.php
+++ b/lib/Sii.php
@@ -655,7 +655,7 @@ class Sii
             curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
         }
         // enviar XML al SII
-        for ($i=0; $i<=$retry; $i++) {
+        for ($i=0; $i<$retry; $i++) {
             $response = curl_exec($curl);
             if ($response and $response!='Error 500') {
                 break;


### PR DESCRIPTION
Este cambio corrige el problema de respuesta de SII al envio
de DTE con error por falta del archivo. Además se corrige el
envio duplicado.